### PR TITLE
renamed to applyMovexStatePatches

### DIFF
--- a/libs/movex/src/lib/util.ts
+++ b/libs/movex/src/lib/util.ts
@@ -27,8 +27,7 @@ export const getJSONPatchDiff = <
   b: B
 ) => jsonpatch.compare(a, b);
 
-// @rename to applyMovexPatches
-export const reconciliatePrivateFragments = <TState extends MovexState>(
+export const applyMovexStatePatches = <TState extends MovexState>(
   state: TState,
   patchesInOrder: JsonPatch<TState>[]
 ): TState => {
@@ -71,5 +70,3 @@ export const getMovexStatePatch = <A, B extends A>(
   // TODO: Empty array if the same??
   return [];
 };
-
-export const applyMovexStatePatches = reconciliatePrivateFragments;


### PR DESCRIPTION
Fixes #28 
I renamed `reconciliatePrivateFragments` to `applyMovexStatePatches` in `libs/movex/src/lib/util.ts`.

Checks:

- [X] Function is renamed
- [X] Removed the alias at the bottom
- [X] No tests fail

Happy Hacktoberfest :)