### PR TITLE
imported the md5 function instead of the whole object-hash

### DIFF
--- a/libs/movex/src/lib/util.ts
+++ b/libs/movex/src/lib/util.ts
@@ -1,9 +1,9 @@
 import * as jsonpatch from 'fast-json-patch';
-import hash from 'object-hash';
+import { MD5 } from 'object-hash';
 import { isObject, JsonPatch, NotUndefined } from 'movex-core-util';
 import { CheckedState, MovexState } from './core-types';
 
-export const hashObject = (val: NotUndefined) => hash.MD5(val);
+export const hashObject = (val: NotUndefined) => MD5(val);
 
 export const computeCheckedState = <T>(state: T): CheckedState<T> => [
   state,


### PR DESCRIPTION
Fixes #30

**Checks**

- [x] resulted hash/token is the same when run in the browser AND on the server (node)
 - [x] All tests are passing `yarn test`
 - [x] The library decreased in size 