### PR TITLE
Adding clearAll tests to MemoryMovexStore.spec.ts

### DIFF
--- a/libs/movex/src/lib/movex-store/MemoryMovexStore.spec.ts
+++ b/libs/movex/src/lib/movex-store/MemoryMovexStore.spec.ts
@@ -100,3 +100,44 @@ describe('Concurrency', () => {
     expect(actual.state[0].count).toBe(21);
   });
 });
+
+describe('clearAll functionality', () => {
+  test('clearAll with an empty store', async () => {
+    const store = new MemoryMovexStore<{ counter: () => { count: number } }>();
+    await store.clearAll();
+    expect(store.all()).toEqual({});
+  });
+
+  test('newly created items are not there after clearAll', async () => {
+    const store = new MemoryMovexStore<{ counter: () => { count: number } }>();
+    await store.create('counter:1', { count: 1 });
+    await store.clearAll();
+    expect(store.all()).toEqual({});
+  });
+
+  test('clearAll after items are updated', async () => {
+    const store = new MemoryMovexStore<{ counter: () => { count: number } }>();
+    await store.create('counter:1', { count: 1 });
+    await store.updateState('counter:1', (prev) => ({ count: prev.count + 1 }));
+    await store.clearAll();
+    expect(store.all()).toEqual({});
+  });
+
+  test('clearAll after items are removed', async () => {
+    const store = new MemoryMovexStore<{ counter: () => { count: number } }>();
+    await store.create('counter:1', { count: 1 });
+    await store.remove('counter:1');
+    await store.clearAll();
+    expect(store.all()).toEqual({});
+  });
+
+  test('clearAll after multiple operations', async () => {
+    const store = new MemoryMovexStore<{ counter: () => { count: number } }>();
+    await store.create('counter:1', { count: 1 });
+    await store.updateState('counter:1', (prev) => ({ count: prev.count + 1 }));
+    await store.remove('counter:1');
+    await store.create('counter:2', { count: 2 });
+    await store.clearAll();
+    expect(store.all()).toEqual({});
+  });
+});}


### PR DESCRIPTION
related to issue #46 
last one fails..
           expect(received).toEqual(expected) // deep equality
       
           - Expected  -  1
           + Received  + 14
       
           - Object {}
           + Object {
           +   "counter": Object {
           +     "counter:1": Object {
           +       "rid": "counter:1",
           +       "state": Array [
           +         Object {
           +           "count": 2,
           +         },
           +         "4ff62b6299694959981a28551da28e41",
           +       ],
           +       "subscribers": Object {},
           +     },
           +   },
           + }
       
             140 |     await store.create('counter:2', { count: 2 });
             141 |     await store.clearAll();
           > 142 |     expect(store.all()).toEqual({});
                 |                         ^
             143 |   });
             144 | });
             145 |
       
