### PR TITLE
removed applyAction() comment

### DIFF
--- a/libs/movex/src/specs/MovexClientResourceObservable.spec.ts
+++ b/libs/movex/src/specs/MovexClientResourceObservable.spec.ts
@@ -52,32 +52,6 @@ describe('Observable', () => {
     expect(xResource.getUncheckedState()).toEqual({ count: 4 });
   });
 
-  // TODO: the applyAction got deprecated (for now). It was only used in createMasterEnv anyway
-  // test('Apply Local Actions', () => {
-  //   const xResource = new MovexResourceObservable(counterReducer);
-
-  //   xResource.applyAction({
-  //     type: 'increment',
-  //   });
-
-  //   expect(xResource.getUncheckedState()).toEqual({ count: 1 });
-
-  //   xResource.onUpdated((nextCheckedState) => {
-  //     expect(nextCheckedState).toEqual(
-  //       computeCheckedState({
-  //         count: 4,
-  //       })
-  //     );
-  //   });
-
-  //   xResource.dispatch({
-  //     type: 'incrementBy',
-  //     payload: 3,
-  //   });
-
-  //   expect(xResource.getUncheckedState()).toEqual({ count: 4 });
-  // });
-
   describe('External Updates', () => {
     test('updates the unchecked state', async () => {
       const xResource = new MovexResourceObservable(


### PR DESCRIPTION
Fixes #61 

Hey I removed the `applyAction()` comment in `libs/movex/src/specs/MovexClientResourceObservable.spec.ts`.

Checks:

- [X] the commented code is removed
- [X] no other test is touched
- [X] all tests keep passing yarn test

![image](https://github.com/movesthatmatter/movex/assets/66525499/ea868cf0-3f04-4a05-bfeb-be2a7576c989)
