### PR TITLE
removed applyAction() function

### DIFF
--- a/libs/movex/src/lib/client/MovexResourceObservable.ts
+++ b/libs/movex/src/lib/client/MovexResourceObservable.ts
@@ -117,19 +117,6 @@ export class MovexResourceObservable<
     this.dispatcher([privateAction, publicAction]);
   }
 
-  /**
-   * The difference between this and the dispatch is that this happens in sync and returns the next state,
-   * while dispatch() MIGHT not happen in sync and doesn't return
-   *
-   * @param actionOrActionTuple
-   * @returns
-   */
-  applyAction(action: ToPublicAction<TAction>) {
-    return this.$checkedState
-      .update(this.getNextCheckedStateFromAction(action))
-      .get();
-  }
-
   applyMultipleActions(actions: ToPublicAction<TAction>[]) {
     const nextState = actions.reduce(
       (prev, action) => this.computeNextState(prev, action),


### PR DESCRIPTION
Fixes #60 

I removed the now deprecated function `applyAction()` in `libs/movex/src/lib/client/MovexResourceObservable.ts`.

Checks:
- [X] Removed the function
-  [X] No tests fail

![image](https://github.com/movesthatmatter/movex/assets/66525499/afb08de3-68cc-4e51-8118-fd075b8daaf5)
