### PR TITLE
Corrected Typo in the documentation

### DIFF
--- a/apps/movex-docs/pages/docs/how.mdx
+++ b/apps/movex-docs/pages/docs/how.mdx
@@ -1,6 +1,6 @@
 # How does Movex work
 
-Movex follows the [Flux Pattern](https://redux.js.org/understanding/history-and-design/prior-art#flux) locally to respond to changes in the UI, and then uses the "Deterministic Propagation Method" to sync up teh state changes with the Global State as well as with all the peers in the network.
+Movex follows the [Flux Pattern](https://redux.js.org/understanding/history-and-design/prior-art#flux) locally to respond to changes in the UI, and then uses the "Deterministic Propagation Method" to sync up the state changes with the Global State as well as with all the peers in the network.
 <br/>
 <br/>
 <div className="bg-slate-100 p-8 text-center">


### PR DESCRIPTION
Fixes #73 

Checks:

 - [x] Spelling now corrected 
 - [x] all tests pass yarn test