### PR TITLE
refactor: 💡 Implement IObservable for Observable

### DIFF
--- a/libs/movex-core-util/src/lib/core-util/Observable.ts
+++ b/libs/movex-core-util/src/lib/core-util/Observable.ts
@@ -9,11 +9,11 @@ export const getNextStateFrom = <T>(prev: T, a: NextStateGetter<T>) => {
 
 export interface IObservable<T> {
   get: () => T;
-  onUpdated: (fn: (state: T) => void) => () => void;
+  onUpdate: (fn: (state: T) => void) => () => void;
   update: (getNextState: T | ((prev: T) => T)) => void;
 }
 
-export class Observable<T> {
+export class Observable<T> implements IObservable<T>{
   private pubsy = new Pubsy<{
     onUpdate: T;
   }>();

--- a/libs/movex/src/lib/client/MovexResourceObservable.ts
+++ b/libs/movex/src/lib/client/MovexResourceObservable.ts
@@ -167,7 +167,7 @@ export class MovexResourceObservable<
     return this.reducer(prevState, action);
   }
 
-  onUpdated(fn: (state: CheckedState<TState>) => void) {
+  onUpdate(fn: (state: CheckedState<TState>) => void) {
     // return this.$checkedState.onUpdate(([state]) => fn(state));
     return this.$checkedState.onUpdate(fn);
   }

--- a/libs/movex/src/specs/MovexClientResourceObservable.spec.ts
+++ b/libs/movex/src/specs/MovexClientResourceObservable.spec.ts
@@ -34,7 +34,7 @@ describe('Observable', () => {
 
     expect(xResource.getUncheckedState()).toEqual({ count: 1 });
 
-    xResource.onUpdated((nextCheckedState) => {
+    xResource.onUpdate((nextCheckedState) => {
       expect(nextCheckedState).toEqual(
         computeCheckedState({
           count: 4,
@@ -93,7 +93,7 @@ describe('Observable', () => {
         );
 
         const updateSpy = jest.fn();
-        xResource.onUpdated(updateSpy);
+        xResource.onUpdate(updateSpy);
 
         const [incrementedState, incrementedStateChecksum] =
           computeCheckedState({
@@ -126,7 +126,7 @@ describe('Observable', () => {
         );
 
         const updateSpy = jest.fn();
-        xResource.onUpdated(updateSpy);
+        xResource.onUpdate(updateSpy);
 
         const actual = xResource.reconciliateAction({
           action: {


### PR DESCRIPTION
Also use onUpdate naming instead of onUpdated to be inline with the interface.

Checks:
- [x] Observable class implements IObservable interface correctly
- [x] all tests pass yarn test

Issues:
- [x] Closes: #77 