### PR TITLE
fix: added `nx` runner for `tsx` compiler + property `onUpdated` fixed

### DIFF
--- a/libs/movex-react/project.json
+++ b/libs/movex-react/project.json
@@ -5,6 +5,16 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "tsc": {
+      "executor": "nx:run-commands",
+      "options": {
+          "commands": [
+              {
+                  "command": "tsc --noEmit -p libs/movex-react/tsconfig.lib.json"
+              }
+          ]
+      }
+    },
     "build": {
       "executor": "@nrwl/web:rollup",
       "outputs": ["{options.outputPath}"],

--- a/libs/movex-react/src/lib/hooks.ts
+++ b/libs/movex-react/src/lib/hooks.ts
@@ -120,7 +120,7 @@ export const bindResource = <
 
   onUpdate(new MovexClient.MovexBoundResource($resource));
 
-  const unsubscribe = $resource.onUpdated(() => {
+  const unsubscribe = $resource.onUpdate(() => {
     onUpdate(new MovexClient.MovexBoundResource($resource));
   });
 


### PR DESCRIPTION
Status:
Closes: https://github.com/movesthatmatter/movex/issues/99, https://github.com/movesthatmatter/movex/issues/103

Both issues being co-related

- [x] Added `nx` runner for tsx compiler
- [x] Fixed `onUpdated` bug -> `onUpdate`
- [x] movex-react compiles `npx tsc -b libs/movex-react`
- [x] all regression tests are passing `yarn test`
- [x] can run `npx nx tsc movex-react --watch`

![image](https://github.com/movesthatmatter/movex/assets/106394426/0cbf5d02-13d9-4114-b134-54714bd3cd70)

![image](https://github.com/movesthatmatter/movex/assets/106394426/c26a3f28-06c1-4a4d-bdcf-4e1447972afd)
