### PR TITLE
fix(lib/movex): Added nx runner for tsc compiler

### DIFF
--- a/libs/movex/project.json
+++ b/libs/movex/project.json
@@ -4,6 +4,16 @@
   "sourceRoot": "libs/movex/src",
   "projectType": "library",
   "targets": {
+    "tsc": {
+      "executor": "nx:run-commands",
+      "options": {
+          "commands": [
+              {
+                  "command": "tsc --noEmit -p libs/movex/tsconfig.lib.json"
+              }
+          ]
+      }
+    },
     "build": {
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],


### PR DESCRIPTION
Status:
Closes: https://github.com/movesthatmatter/movex/issues/98

- [x] Added `nx` runner for `tsx` compiler
- [x] can run `npx nx tsc movex`
- [x] can run `npx nx tsc movex --watch`

![image](https://github.com/movesthatmatter/movex/assets/106394426/78f69440-bc30-4305-8fd2-9c09b5d903c6)
