### PR TITLE
refactor: 💡 Fix linting errors in libs/movex-react

### DIFF
--- a/libs/movex-core-util/src/lib/core-util/EventEmitter.ts
+++ b/libs/movex-core-util/src/lib/core-util/EventEmitter.ts
@@ -2,6 +2,10 @@ import { EventMap } from 'typed-emitter';
 
 export type UnsubscribeFn = () => void;
 
+export type EmptyFn = () => void;
+
+export const emptyFn: EmptyFn = () => {};
+
 export interface EventEmitter<TEventMap extends EventMap> {
   on<E extends keyof TEventMap>(
     event: E,

--- a/libs/movex-react/src/lib/MovexProvider.tsx
+++ b/libs/movex-react/src/lib/MovexProvider.tsx
@@ -22,7 +22,7 @@ type Props<TMovexConfigResourcesMap extends BaseMovexDefinitionResourcesMap> =
     ) => void;
   }>;
 
-export const MovexProvider: React.FC<Props<{}>> = ({
+export const MovexProvider: React.FC<Props<BaseMovexDefinitionResourcesMap>> = ({
   onConnected = noop,
   onDisconnected = noop,
   ...props

--- a/libs/movex-react/src/lib/hooks.ts
+++ b/libs/movex-react/src/lib/hooks.ts
@@ -4,6 +4,7 @@ import {
   isResourceIdentifier,
   toResourceIdentifierObj,
   toResourceIdentifierStr,
+  UnsubscribeFn
 } from 'movex-core-util';
 import {
   MovexClient,
@@ -197,7 +198,7 @@ export const useMovexBindOrCreateAndBindOnDemand = <
       return;
     }
 
-    let unsubscribers: Function[] = [];
+    let unsubscribers: UnsubscribeFn[] = [];
 
     const bind = (rid: ResourceIdentifier<TResourceType>) => {
       const resource = registerMovexResourceType(

--- a/libs/movex-react/src/lib/movex-local/MovexLocalMasterProvider.tsx
+++ b/libs/movex-react/src/lib/movex-local/MovexLocalMasterProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StringKeys, invoke, logsy, noop } from 'movex-core-util';
+import { StringKeys, invoke, logsy, noop, emptyFn } from 'movex-core-util';
 import {
   BaseMovexDefinitionResourcesMap,
   GetReducerState,
@@ -31,7 +31,7 @@ type Props<TMovexConfigResourcesMap extends BaseMovexDefinitionResourcesMap> =
  * @param param0
  * @returns
  */
-export const MovexLocalMasterProvider: React.FC<Props<{}>> = ({
+export const MovexLocalMasterProvider: React.FC<Props<BaseMovexDefinitionResourcesMap>> = ({
   onInit = noop,
   onMasterResourceUpdated = noop,
   ...props
@@ -85,7 +85,7 @@ export const MovexLocalMasterProvider: React.FC<Props<{}>> = ({
       };
     }
 
-    return () => {};
+    return emptyFn;
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
- [x] running `npx nx lint movex-react --quiet` will not return any more errors
- [x] tsc passes `npx nx tsc movex-react`
- [x] all tests pass `yarn lint`
- [x] no unnecessary code is introduced

Closes: #121 