### PR TITLE
Fix linting errors in libs/movex-server

### DIFF
--- a/libs/movex-server/src/bin.ts
+++ b/libs/movex-server/src/bin.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint @typescript-eslint/no-var-requires: 0 */
 
 const cwd = require('process').cwd();
 const esb = require('esbuild');


### PR DESCRIPTION
- [x] running `npx nx lint movex-server --quiet` will not return any more errors

Closes: [#130](https://github.com/movesthatmatter/movex/issues/130)