### PR TITLE
Fixed all linting issues of movex-core-util

### DIFF
--- a/libs/movex-core-util/src/lib/core-types.ts
+++ b/libs/movex-core-util/src/lib/core-types.ts
@@ -1,5 +1,6 @@
 import { UnknownRecord } from './core-util';
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace NestedObjectUtil {
   // The Paths Types is taken from https://stackoverflow.com/a/58436959/2093626
 
@@ -139,7 +140,7 @@ export type UnknownIdentifiableRecord = { id: string } & Record<
 >;
 export type AnyIdentifiableRecord = { id: string } & Record<string, any>;
 
-export type UnidentifiableModel<T extends {}> = Omit<T, 'id'>;
+export type UnidentifiableModel<T extends object> = Omit<T, 'id'>;
 
 // TODO: Remove all of these if not used
 
@@ -202,7 +203,7 @@ export type GenericResourceOfType<TResourceType extends string> = Resource<
 
 export type GenericResourceType = GenericResource['type'];
 
-export type MovexClient<Info extends UnknownRecord = {}> = {
+export type MovexClient<Info extends UnknownRecord = Record<string, never>> = {
   id: string;
   info?: Info; // User Info or whatever
   subscriptions: Record<
@@ -289,7 +290,12 @@ export type SessionStoreCollectionMap<
 export type OnlySessionCollectionMapOfResourceKeys<
   ResourceCollectionMap extends CollectionMapBase,
   SessionCollectionMap = SessionStoreCollectionMap<ResourceCollectionMap>
-> = StringKeys<Omit<SessionCollectionMap, keyof SessionStoreCollectionMap<{}>>>;
+> = StringKeys<
+  Omit<
+    SessionCollectionMap,
+    keyof SessionStoreCollectionMap<Record<string, never>>
+  >
+>;
 
 export type CreateMatchReq<TGame extends UnknownRecord> = {
   matcher: SessionMatch['matcher'];

--- a/libs/movex-core-util/src/lib/core-util/EventEmitter.ts
+++ b/libs/movex-core-util/src/lib/core-util/EventEmitter.ts
@@ -34,5 +34,3 @@ export interface EventEmitter<TEventMap extends EventMap> {
     request: Parameters<TEventMap[E]>[0]
   ): Promise<ReturnType<TEventMap[E]>>;
 }
-
-export interface EmitterEventMap extends EventMap {}

--- a/libs/movex-core-util/src/lib/core-util/Logsy.ts
+++ b/libs/movex-core-util/src/lib/core-util/Logsy.ts
@@ -9,9 +9,9 @@ type LogsyMethods =
   | 'groupEnd'
   | 'debug';
 
-var globalDisabled: boolean = false;
+const globalDisabled = false;
 
-var globalLogsyConfigWrapper = {
+const globalLogsyConfigWrapper = {
   config: {
     disabled: false,
     verbose: false,
@@ -32,15 +32,18 @@ class Logsy {
 
   private handler = (
     method: LogsyMethods,
-    message?: any,
-    ...optionalParams: any[]
+    message?: string | object,
+    ...optionalParams: unknown[]
   ) => {
     if (!this.ON || globalLogsyConfigWrapper.config.disabled) {
       return;
     }
 
     // If verbose is false, we don't want to log, info or debug
-    if ((method === 'log' || method === 'info' || method === 'debug') && !globalLogsyConfigWrapper.config.verbose) {
+    if (
+      (method === 'log' || method === 'info' || method === 'debug') &&
+      !globalLogsyConfigWrapper.config.verbose
+    ) {
       return;
     }
 

--- a/libs/movex-core-util/src/lib/core-util/ResultError.ts
+++ b/libs/movex-core-util/src/lib/core-util/ResultError.ts
@@ -40,11 +40,7 @@ export const isResultError = (
   keyInObject(e, 'reason') &&
   typeof e.reason === 'string';
 
-export const isResultErrorOfKind = <
-  K extends string,
-  R extends string,
-  C extends unknown
->(
+export const isResultErrorOfKind = <K extends string, R extends string, C>(
   type: K,
   e: ResultError<{ type: K; reason: string; content?: unknown }>
 ): e is ResultError<{ type: K; reason: R; content: C }> =>
@@ -53,7 +49,7 @@ export const isResultErrorOfKind = <
 export const isResultErrorOfKindAndReason = <
   K extends string,
   R extends string,
-  C extends unknown
+  C
 >(
   type: K,
   reason: R,
@@ -64,7 +60,7 @@ export const isResultErrorOfKindAndReason = <
 export const buildResultError = <
   K extends string,
   R extends string,
-  C extends unknown = undefined
+  C = undefined
 >(
   type: K,
   reason: R,

--- a/libs/movex-core-util/src/lib/core-util/ScketIOEmitter.ts
+++ b/libs/movex-core-util/src/lib/core-util/ScketIOEmitter.ts
@@ -124,7 +124,7 @@ export class SocketIOEmitter<TEventMap extends EventMap>
     event: E,
     request: Parameters<TEventMap[E]>[0]
   ): Promise<ReturnType<TEventMap[E]>> {
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const reqId = `${event as string}(${String(Math.random()).slice(-3)})`;
       logsy.debug(
         '[ServerSocketEmitter]',

--- a/libs/movex-core-util/src/lib/core-util/misc.ts
+++ b/libs/movex-core-util/src/lib/core-util/misc.ts
@@ -27,7 +27,9 @@ export function getRandomInt(givenMin: number, givenMax: number) {
 
 export const invoke = <T>(fn: () => T): T => fn();
 
-export const xinvoke = <T>(fn: () => T) => {};
+export const xinvoke = <T>(fn: () => T) => {
+  // do nothing.
+};
 
 export const delay = (ms = 500) =>
   new Promise((resolve) => {
@@ -37,7 +39,9 @@ export const delay = (ms = 500) =>
 export const range = (length: number, startAt = 0) =>
   Array.from({ length }, (_, i) => i + startAt);
 
-export const noop = () => {};
+export const noop = () => {
+  // do nothing.
+};
 
 export const orThrow = <T>(t: T) => {
   if (t === undefined || t === null) {
@@ -48,7 +52,7 @@ export const orThrow = <T>(t: T) => {
 };
 
 // Use this to get inherited keys as well
-export const keyInObject = <X extends {}, Y extends PropertyKey>(
+export const keyInObject = <X extends object, Y extends PropertyKey>(
   obj: X,
   prop: Y
 ): obj is X & Record<Y, unknown> => prop in obj;
@@ -57,7 +61,7 @@ export const isObject = (o: unknown): o is object => {
   return typeof o === 'object' && !Array.isArray(o) && o !== null;
 };
 
-export const isFunction = (x: unknown): x is Function =>
+export const isFunction = (x: unknown): x is (...args: any) => any =>
   typeof x === 'function';
 
 export const getUuid = uuidV4;

--- a/libs/movex-core-util/src/lib/core-util/types.ts
+++ b/libs/movex-core-util/src/lib/core-util/types.ts
@@ -32,6 +32,6 @@ export type JsonPatchOp<T> =
 export type JsonPatch<T> = JsonPatchOp<T>[];
 
 export type IsOfType<U, T, K> = T extends U ? K : never;
-export type OnlyKeysOfType<T, O extends {}> = {
+export type OnlyKeysOfType<T, O extends object> = {
   [K in keyof O]: IsOfType<T, O[K], K>;
 }[keyof O];


### PR DESCRIPTION
Fixed all linting issues of `lib/movex-core-util`

Closes - 
[#126](https://github.com/movesthatmatter/movex/issues/126) - Fix linting Errors in File: `core-types.ts`
[#127](https://github.com/movesthatmatter/movex/issues/127) - Fix linting Errors in File: `ResultError.ts`
[#128](https://github.com/movesthatmatter/movex/issues/128) - Fix linting Errors in File: `misc.ts `
[#136](https://github.com/movesthatmatter/movex/issues/136) - Fix linting in file `libs/movex-core-util/src/lib/core-util/ScketIOEmitter.ts `
[#138](https://github.com/movesthatmatter/movex/issues/138) - Fix linting Errors in File:` Logsy.ts `
[#139](https://github.com/movesthatmatter/movex/issues/139) - Remove unused `EmitterEventMap` interface
[#140](https://github.com/movesthatmatter/movex/issues/140) - Fix linting Errors in File: `/core-util/types.ts`
