### PR TITLE
fix(libs/movex-core-util): Fixed linting error in resulterror.ts

### DIFF
--- a/libs/movex-core-util/src/lib/core-util/ResultError.ts
+++ b/libs/movex-core-util/src/lib/core-util/ResultError.ts
@@ -43,7 +43,7 @@ export const isResultError = (
 export const isResultErrorOfKind = <
   K extends string,
   R extends string,
-  C extends unknown
+  C
 >(
   type: K,
   e: ResultError<{ type: K; reason: string; content?: unknown }>
@@ -53,7 +53,7 @@ export const isResultErrorOfKind = <
 export const isResultErrorOfKindAndReason = <
   K extends string,
   R extends string,
-  C extends unknown
+  C
 >(
   type: K,
   reason: R,
@@ -64,7 +64,7 @@ export const isResultErrorOfKindAndReason = <
 export const buildResultError = <
   K extends string,
   R extends string,
-  C extends unknown = undefined
+  C = undefined
 >(
   type: K,
   reason: R,


### PR DESCRIPTION
Status:
Closes: https://github.com/movesthatmatter/movex/issues/127

Fixed linting issues occuring in `ResultError.ts` in `libs/movex-core-util`