### PR TITLE
Fix "[project] Rename the Github Action: node.js.yml #150" and "[project] Remove the node-18.x from CI Github Action #149"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Done Issue #149 and Issue #150 :

- Renamed the name field from CI to Tests
- Renamed the workflow file name from node.js.yml to test.yml
- Removed the 18.x from the node-versions matrix