### PR TITLE
Add "[movex-docs] Add lazy loader to Examples section #151"

### DIFF
--- a/apps/movex-docs/pages/index.mdx
+++ b/apps/movex-docs/pages/index.mdx
@@ -97,6 +97,7 @@ import { features, faqs, community } from '../modules/home/homeVars';
         borderRight: 'solid black 16px',
       }}
       title="rps-demo"
+      loading="lazy"
       allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
       sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
     />
@@ -111,6 +112,7 @@ import { features, faqs, community } from '../modules/home/homeVars';
         borderRight: 'solid black 16px',
       }}
       title="rps-demo"
+      loading="lazy"
       allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
       sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
     />


### PR DESCRIPTION
**Fixed Issue #151 :**

- the mobile iframe is getting loaded on the mobile.
- the desktop iframe is getting loaded on the desktop.
- both of them are using lazy loading.

**Video Sample:**

https://github.com/movesthatmatter/movex/assets/116814372/f383fbbb-c2c2-4430-a85a-e86a7e8fea9f


