### PR TITLE
Fixed all linting issues of core-util types.ts

### DIFF
--- a/libs/movex-core-util/src/lib/core-util/types.ts
+++ b/libs/movex-core-util/src/lib/core-util/types.ts
@@ -17,7 +17,6 @@ export type NotUndefined =
   | NotUndefined[];
 
 export type UnknownRecord = Record<string, unknown>;
-export type AnyRecord = Record<string, any>;
 
 export type JsonPatchOp<T> =
   | AddOperation<Partial<T>>
@@ -32,6 +31,7 @@ export type JsonPatchOp<T> =
 export type JsonPatch<T> = JsonPatchOp<T>[];
 
 export type IsOfType<U, T, K> = T extends U ? K : never;
+
 export type OnlyKeysOfType<T, O extends Record<string, unknown>> = {
   [K in keyof O]: IsOfType<T, O[K], K>;
 }[keyof O];


### PR DESCRIPTION
Fixed all linting issues of `libs/movex-core-util/src/lib/core-util/types.ts`
1. Removed `AnyRecord` as it is not used anywhere
2. Changed `object` to a `Record` type

Closes - 
[#140](https://github.com/movesthatmatter/movex/issues/140) - Fix linting Errors in File: `libs/movex-core-util/src/lib/core-util/types.ts`
