### PR TITLE
Fixed linting in 'io-events.ts'

### DIFF
--- a/libs/movex/src/lib/io-connection/io-events.ts
+++ b/libs/movex/src/lib/io-connection/io-events.ts
@@ -9,7 +9,7 @@ import {
 } from '../tools/action';
 
 export type IOEvents<
-  TState extends any = any,
+  TState = unknown,
   A extends AnyAction = AnyAction,
   TResourceType extends string = string
 > = {


### PR DESCRIPTION
Fixes #165 
This is the simple PR to fix linting in `io-events.ts`.